### PR TITLE
song: Add Bandcamp tracks support

### DIFF
--- a/VocaDB_song_bookmarklet.js
+++ b/VocaDB_song_bookmarklet.js
@@ -237,6 +237,19 @@ javascript: (async function () {
           videoId = videoUrl.split("?v=")[1].split("&")[0];
           break;
         default:
+          if (window.location.host.endsWith(".bandcamp.com")) {
+            service = "Bandcamp";
+            const linkedData = JSON.parse(document.querySelector("script[type='application/ld+json']").textContent);
+            for (const prop of linkedData.additionalProperty) {
+              if (prop.name == "track_id") {
+                videoId = prop.value;
+              }
+            }
+            if (videoId === undefined) {
+              throw new Error(`Unable to find track_id in Bandcamp data.`);
+            }
+            break;
+          }
           throw new Error(`Unsupported host: ${window.location.host}`);
       }
       const songData = await checkSongInDatabase(videoId, service);
@@ -276,6 +289,8 @@ javascript: (async function () {
         "www.bilibili.com" */
       ].includes(host)
     ) {
+      await handleDirectVideoPage();
+    } else if (host.endsWith(".bandcamp.com")) {
       await handleDirectVideoPage();
     } else {
       alert("This bookmarklet is not supported on this website.");


### PR DESCRIPTION
(From https://gist.github.com/Shiroizu/faf59e536fcdd019f66e7d2cf682c082?permalink_comment_id=5964707#gistcomment-5964707)

Add support for Bandcamp links. For example:
- https://circus-p.bandcamp.com/track/breathe-with-piko opens https://vocadb.net/S/692711 (existing song)
- https://circus-p.bandcamp.com/track/marco-polo-ft-mikamagica opens https://vocadb.net/Song/Create?pvUrl=https://circus-p.bandcamp.com/track/marco-polo-ft-mikamagica (new song)

Invoking on an [album page](https://circus-p.bandcamp.com/album/breathe-with-piko) shows:

<img width="403" height="150" alt="image" src="https://github.com/user-attachments/assets/6e9f2108-ba04-4eae-b36d-be988c81f7b7" />

Other Bandcamp pages might show different errors, but I expect that the common user error is invoking the script on an album page instead of a song page.